### PR TITLE
feat(Choicegroup): added width_full

### DIFF
--- a/src/components/ChoiceGroup/ChoiceGroup.css
+++ b/src/components/ChoiceGroup/ChoiceGroup.css
@@ -90,6 +90,7 @@
     overflow: hidden;
     justify-content: center;
     align-items: center;
+    flex-grow: 1;
     box-sizing: border-box;
     height: var(--choice-height);
     padding: 0 var(--choice-space) 0 var(--choice-space);
@@ -102,8 +103,6 @@
     cursor: pointer;
     transition: background-color 0.15s ease, box-shadow 0.15s ease, color 0.15s ease,
       fill 0.15s ease;
-    flex-grow: 1;
-    flex-shrink: 1;
   }
 
   &-Input {

--- a/src/components/ChoiceGroup/ChoiceGroup.css
+++ b/src/components/ChoiceGroup/ChoiceGroup.css
@@ -1,6 +1,7 @@
 .ChoiceGroup {
   position: relative;
   display: inline-flex;
+  max-width: 100%;
   border-radius: var(--choice-radius);
   box-shadow: inset 0 0 0 var(--control-border-width) var(--color-control-bg-border-default);
 
@@ -86,6 +87,8 @@
     position: relative;
     z-index: 0;
     display: flex;
+    overflow: hidden;
+    justify-content: center;
     align-items: center;
     box-sizing: border-box;
     height: var(--choice-height);
@@ -95,12 +98,12 @@
     font-size: var(--choice-font-size);
     font-weight: normal;
     line-height: calc(var(--choice-height) - var(--control-border-width) * 2);
-    white-space: nowrap;
     text-decoration: none;
-    text-overflow: ellipsis;
     cursor: pointer;
     transition: background-color 0.15s ease, box-shadow 0.15s ease, color 0.15s ease,
       fill 0.15s ease;
+    flex-grow: 1;
+    flex-shrink: 1;
   }
 
   &-Input {
@@ -123,7 +126,7 @@
     position: absolute;
     z-index: -1;
     top: 50%;
-    left: calc(-1 * var(--control-border-width));
+    left: 0;
     width: var(--divider-width);
     height: var(--divider-height);
     transform: translateY(-50%);
@@ -148,6 +151,12 @@
     }
   }
 
+  &-Text {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
   &:not(.ChoiceGroup_onlyIcon) &-Icon {
     margin-right: calc(var(--choice-space) * 0.5);
   }
@@ -158,6 +167,12 @@
       width: calc(var(--choice-height) + var(--control-border-width) * 2);
       padding: 0;
       padding-right: var(--control-border-width);
+    }
+  }
+
+  &_width {
+    &_full {
+      width: 100%;
     }
   }
 }

--- a/src/components/ChoiceGroup/ChoiceGroup.tsx
+++ b/src/components/ChoiceGroup/ChoiceGroup.tsx
@@ -22,6 +22,10 @@ export const choiceGroupViews = ['primary', 'ghost', 'secondary'] as const;
 export type ChoiceGroupPropView = typeof choiceGroupViews[number];
 export const choiceGroupDefaultView: ChoiceGroupPropView = 'primary';
 
+export const choiceGroupWidth = ['default', 'full'] as const;
+export type СhoiceGroupPropWidth = typeof choiceGroupWidth[number];
+export const choiceGroupWidthDefault: СhoiceGroupPropWidth = choiceGroupWidth[0];
+
 export type ChoiceGroupPropGetLabel<ITEM> = (item: ITEM) => string | number;
 export type ChoiceGroupPropGetIcon<ITEM> = (item: ITEM) => React.FC<IconProps> | undefined;
 
@@ -29,6 +33,7 @@ type CommonProps<ITEM> = {
   size?: ChoiceGroupPropSize;
   form?: ChoiceGroupPropForm;
   view?: ChoiceGroupPropView;
+  width?: СhoiceGroupPropWidth;
   onlyIcon?: boolean;
   iconSize?: IconPropSize;
   items: ITEM[];
@@ -71,6 +76,7 @@ export const ChoiceGroup: ChoiceGroup = React.forwardRef<HTMLDivElement, Props>(
     size = choiceGroupDefaultSize,
     form = choiceGroupDefaultForm,
     view = choiceGroupDefaultView,
+    width = choiceGroupWidthDefault,
     onlyIcon,
     iconSize: iconSizeProp,
     value,
@@ -100,7 +106,7 @@ export const ChoiceGroup: ChoiceGroup = React.forwardRef<HTMLDivElement, Props>(
     <div
       {...otherProps}
       ref={ref}
-      className={cnChoiceGroup({ size, form, view, onlyIcon }, [className])}
+      className={cnChoiceGroup({ size, form, view, width, onlyIcon }, [className])}
     >
       {items.map((item: unknown) => (
         <ChoiceGroupItem

--- a/src/components/ChoiceGroup/Item/ChoiceGroup-Item.tsx
+++ b/src/components/ChoiceGroup/Item/ChoiceGroup-Item.tsx
@@ -38,7 +38,7 @@ export const ChoiceGroupItem: React.FC<Props> = (props) => {
         name={name}
       />
       {Icon && <Icon className={cnChoiceGroup('Icon')} size={iconSize} />}
-      {!onlyIcon && label}
+      {!onlyIcon && <span className={cnChoiceGroup('Text')}>{label}</span>}
     </label>
   );
 };

--- a/src/components/ChoiceGroup/__stories__/ChoiceGroup.mdx
+++ b/src/components/ChoiceGroup/__stories__/ChoiceGroup.mdx
@@ -3,6 +3,7 @@ import { ChoiceGroupExampleView } from './examples/ChoiceGroupExampleView/Choice
 import { ChoiceGroupExampleForm } from './examples/ChoiceGroupExampleForm/ChoiceGroupExampleForm';
 import { ChoiceGroupExampleSize } from './examples/ChoiceGroupExampleSize/ChoiceGroupExampleSize';
 import { ChoiceGroupExampleText } from './examples/ChoiceGroupExampleText/ChoiceGroupExampleText';
+import { ChoiceGroupExampleWidth } from './examples/ChoiceGroupExampleWidth/ChoiceGroupExampleWidth';
 import {
   ChoiceGroupExampleOne,
   ChoiceGroupExampleMultiple,
@@ -23,6 +24,8 @@ import {
 
 Занимает больше места, зато по элементам проще попасть, чем по радиокнопкам
 или чекбоксам.
+
+Не рекомендуется использовать в одной группе **больше шести** кнопок.
 
 > Не используйте ChoiceGroup для навигации верхнего уровня, например, в шапке сайта
 
@@ -91,6 +94,12 @@ import {
 За размер компонента отвечает свойство `size`. Варианты: `'xs', 's', 'm', 'l'`.
 
 <ChoiceGroupExampleSize />
+
+### Группа кнопок в ширину блока
+
+Используется для поддержания области формы или отделения наследуемых частей формы от основных.
+
+<ChoiceGroupExampleWidth />
 
 ## Свойства
 

--- a/src/components/ChoiceGroup/__stories__/ChoiceGroup.mdx
+++ b/src/components/ChoiceGroup/__stories__/ChoiceGroup.mdx
@@ -3,6 +3,7 @@ import { ChoiceGroupExampleView } from './examples/ChoiceGroupExampleView/Choice
 import { ChoiceGroupExampleForm } from './examples/ChoiceGroupExampleForm/ChoiceGroupExampleForm';
 import { ChoiceGroupExampleSize } from './examples/ChoiceGroupExampleSize/ChoiceGroupExampleSize';
 import { ChoiceGroupExampleText } from './examples/ChoiceGroupExampleText/ChoiceGroupExampleText';
+import { ChoiceGroupExampleTextOverflow } from './examples/ChoiceGroupExampleTextOverflow/ChoiceGroupExampleTextOverflow';
 import { ChoiceGroupExampleWidth } from './examples/ChoiceGroupExampleWidth/ChoiceGroupExampleWidth';
 import {
   ChoiceGroupExampleOne,
@@ -69,6 +70,10 @@ import {
 
 <ChoiceGroupExampleText />
 
+Когда текст в группе кнопок довольно большой, а область для кнопок выделена небольшая, то текст сокращается до многоточия.
+
+<ChoiceGroupExampleTextOverflow />
+
 ## Иконки
 
 Чтобы показать иконку на кнопке, используйте `getItemIcon`.
@@ -97,6 +102,7 @@ import {
 
 ### Группа кнопок в ширину блока
 
+За ширину компонента отвечает свойство `width`. Варианты: `'full', 'default'`.
 Используется для поддержания области формы или отделения наследуемых частей формы от основных.
 
 <ChoiceGroupExampleWidth />
@@ -112,21 +118,22 @@ type OnChangeMultiple = (props: { e: React.ChangeEvent<HTMLInputElement>; value:
 
 ```
 
-| Свойство                          | Тип                                              | По умолчанию | Описание                                                                                                                                               |
-| --------------------------------- | ------------------------------------------------ | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `items`                           | `Item[]`                                         | —            | Элементы                                                                                                                                               |
-| [`multiple`](#один-или-несколько) | `boolean`                                        | —            | Выбрать несколько вариантов                                                                                                                            |
-| `value`                           | multiple ? `Item[]` : `Item` or `null`           | —            | Значение                                                                                                                                               |
-| `onChange`                        | multiple ? `onChangeMultiple` : `OnChange`       | —            | Действие при выборе элемента                                                                                                                           |
-| `name`                            | `string`                                         | —            | Имя `<input>`, указывается для доступности                                                                                                             |
-| [`getLabel`](#текст-на-кнопках)   | `(item: Item) => string, number`                 | —            | Функция для формирования текста для кнопки или всплывающей подсказки (при `onlyIcon = true`). Также используется в качестве уникального ключа элемента |
-| [`getIcon`](#иконки)              | `(item: Item) => React.FC<IconProps>, undefined` | —            | Функция для формирования иконки                                                                                                                        |
-| [`onlyIcon?`](#иконки)            | `boolean`                                        | —            | Показывать только иконку                                                                                                                               |
-| [`size?`](#размер)                | `'xs', 's', 'm', 'l'`                            | `'m'`        | Размер                                                                                                                                                 |
-| [`form?`](#форма-кнопок)          | `'default', 'brick', 'round'`                    | `'default'`  | Форма                                                                                                                                                  |
-| [`view?`](#внешний-вид)           | `'primary', 'ghost', 'secondary'`                | `'primary'`  | Внешний вид                                                                                                                                            |
-| `className?`                      | `string`                                         | —            | Дополнительный CSS-класс                                                                                                                               |
-| `ref?`                            | `React.Ref<HTMLDivElement>`                      | -            | Ссылка на корневой DOM-элемент этого компонента                                                                                                        |
+| Свойство                                    | Тип                                              | По умолчанию | Описание                                                                                                                                               |
+| ------------------------------------------- | ------------------------------------------------ | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `items`                                     | `Item[]`                                         | —            | Элементы                                                                                                                                               |
+| [`multiple`](#один-или-несколько)           | `boolean`                                        | —            | Выбрать несколько вариантов                                                                                                                            |
+| `value`                                     | multiple ? `Item[]` : `Item` or `null`           | —            | Значение                                                                                                                                               |
+| `onChange`                                  | multiple ? `onChangeMultiple` : `OnChange`       | —            | Действие при выборе элемента                                                                                                                           |
+| `name`                                      | `string`                                         | —            | Имя `<input>`, указывается для доступности                                                                                                             |
+| [`getLabel`](#текст-на-кнопках)             | `(item: Item) => string, number`                 | —            | Функция для формирования текста для кнопки или всплывающей подсказки (при `onlyIcon = true`). Также используется в качестве уникального ключа элемента |
+| [`getIcon`](#иконки)                        | `(item: Item) => React.FC<IconProps>, undefined` | —            | Функция для формирования иконки                                                                                                                        |
+| [`onlyIcon?`](#иконки)                      | `boolean`                                        | —            | Показывать только иконку                                                                                                                               |
+| [`size?`](#размер)                          | `'xs', 's', 'm', 'l'`                            | `'m'`        | Размер                                                                                                                                                 |
+| [`form?`](#форма-кнопок)                    | `'default', 'brick', 'round'`                    | `'default'`  | Форма                                                                                                                                                  |
+| [`view?`](#внешний-вид)                     | `'primary', 'ghost', 'secondary'`                | `'primary'`  | Внешний вид                                                                                                                                            |
+| [`width?`](#группа-кнопок-в-ширину-блока) | `'default', 'full'`                              | `'default'`  | Ширина компонента                                                                                                                                      |
+| `className?`                                | `string`                                         | —            | Дополнительный CSS-класс                                                                                                                               |
+| `ref?`                                      | `React.Ref<HTMLDivElement>`                      | -            | Ссылка на корневой DOM-элемент этого компонента                                                                                                        |
 
 ## Пример
 

--- a/src/components/ChoiceGroup/__stories__/ChoiceGroup.stories.tsx
+++ b/src/components/ChoiceGroup/__stories__/ChoiceGroup.stories.tsx
@@ -15,6 +15,8 @@ import {
   choiceGroupForms,
   choiceGroupSizes,
   choiceGroupViews,
+  choiceGroupWidth,
+  choiceGroupWidthDefault,
 } from '../ChoiceGroup';
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
@@ -43,6 +45,7 @@ const items = [
 
 const defaultKnobs = () => ({
   multiple: boolean('multiple', false),
+  width: select('width', choiceGroupWidth, choiceGroupWidthDefault),
   size: select('size', choiceGroupSizes, choiceGroupDefaultSize),
   view: select('view', choiceGroupViews, choiceGroupDefaultView),
   form: select('form', choiceGroupForms, choiceGroupDefaultForm),
@@ -55,7 +58,7 @@ const cnChoiceGroupStories = cn('ChoiceGroupStories');
 export function Playground() {
   const [valueMultiple, setValueMultiple] = useState<Item[] | null>(null);
   const [value, setValue] = useState<Item | null>(null);
-  const { multiple, size, view, form, withIcon, onlyIcon } = defaultKnobs();
+  const { multiple, size, view, width, form, withIcon, onlyIcon } = defaultKnobs();
 
   const getIcon = withIcon ? (item: Item) => item.icon : undefined;
   const getLabel = (item: Item) => item.name;
@@ -75,6 +78,7 @@ export function Playground() {
             multiple
             size={size}
             view={view}
+            width={width}
             form={form}
             onlyIcon={onlyIcon}
             getIcon={getIcon}
@@ -89,6 +93,7 @@ export function Playground() {
             multiple={false}
             size={size}
             view={view}
+            width={width}
             form={form}
             onlyIcon={onlyIcon}
             getIcon={getIcon}

--- a/src/components/ChoiceGroup/__stories__/examples/ChoiceGroupExampleMultiple/ChoiceGroupExampleMultiple.tsx
+++ b/src/components/ChoiceGroup/__stories__/examples/ChoiceGroupExampleMultiple/ChoiceGroupExampleMultiple.tsx
@@ -6,7 +6,7 @@ import { ChoiceGroup } from '../../../ChoiceGroup';
 
 type Item = string;
 
-const items: Item[] = ['один', 'два', 'три', 'четыре', 'пять', 'шесть', 'семь'];
+const items: Item[] = ['один', 'два', 'три', 'четыре', 'пять', 'шесть'];
 
 export const ChoiceGroupExampleOne = () => {
   const [value, setValue] = useState<Item | null>(items[0]);

--- a/src/components/ChoiceGroup/__stories__/examples/ChoiceGroupExampleTextOverflow/ChoiceGroupExampleTextOverflow.tsx
+++ b/src/components/ChoiceGroup/__stories__/examples/ChoiceGroupExampleTextOverflow/ChoiceGroupExampleTextOverflow.tsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+
+import { cnDocsDecorator } from '../../../../../uiKit/components/DocsDecorator/DocsDecorator';
+import { StoryBookExample } from '../../../../../uiKit/components/StoryBookExample/StoryBookExample';
+import { ChoiceGroup } from '../../../ChoiceGroup';
+
+type Item = string;
+
+const items: Item[] = [
+  'Экриксинатозавр',
+  'Пахицефалозавр',
+  'Жираффатитан',
+  'Аргентинозавр',
+  'Кархародонтозавр',
+];
+
+export const ChoiceGroupExampleTextOverflow = () => {
+  const [value, setValue] = useState<Item | null>(items[0]);
+  return (
+    <StoryBookExample className={cnDocsDecorator('Section')}>
+      <ChoiceGroup
+        value={value}
+        onChange={({ value }) => setValue(value)}
+        items={items}
+        getLabel={(item) => item}
+        multiple={false}
+        name="ChoiceGroupExampleTextOverflow"
+      />
+    </StoryBookExample>
+  );
+};

--- a/src/components/ChoiceGroup/__stories__/examples/ChoiceGroupExampleWidth/ChoiceGroupExampleWidth.tsx
+++ b/src/components/ChoiceGroup/__stories__/examples/ChoiceGroupExampleWidth/ChoiceGroupExampleWidth.tsx
@@ -1,0 +1,26 @@
+import React, { useState } from 'react';
+
+import { cnDocsDecorator } from '../../../../../uiKit/components/DocsDecorator/DocsDecorator';
+import { StoryBookExample } from '../../../../../uiKit/components/StoryBookExample/StoryBookExample';
+import { ChoiceGroup } from '../../../ChoiceGroup';
+
+type Item = string;
+
+const items: Item[] = ['один', 'два', 'три'];
+
+export const ChoiceGroupExampleWidth = () => {
+  const [value, setValue] = useState<Item | null>(items[0]);
+  return (
+    <StoryBookExample className={cnDocsDecorator('Section')}>
+      <ChoiceGroup
+        value={value}
+        onChange={({ value }) => setValue(value)}
+        items={items}
+        getLabel={(item) => item}
+        multiple={false}
+        width="full"
+        name="ChoiceGroupExampleWidth"
+      />
+    </StoryBookExample>
+  );
+};


### PR DESCRIPTION
closes #549 

## Описание изменений
Добавляет модификатор width_full, растягивающий группу кнопок на всю ширину родителя. В фигму такой модификатор тоже добавлен.
Также добавлено обрезание слишком длинного текста во всех размерах, если группа кнопок не влезает в родителя.

## Чек-лист

- [x] PR: направлен в правильную ветку
- [x] PR: назначен исполнитель PR и указаны нужные лейблы
- [ ] PR: проверен diff, ничего лишнего в PR не попало
- [x] PR: прилинкованы затронутые issue и связанные PR
- [x] PR: есть описание изменений
- [ ] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [x] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [x] Сторибук: для компонентов написаны или обновлены stories
- [x] Верстка: используются [переменные](../src/components/Theme)
- [x] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [ ] Коммиты: проименованы в соответствии с [правилами](https://consta-uikit.vercel.app/?path=/docs/common-develop-commits-style--page)
