### PR TITLE
feat(Table): set columns widths after 1st render for disabling autore…

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -193,11 +193,17 @@ export const Table = <T extends TableRow>({
       return;
     }
 
-    setInitialColumnWidths(
-      columnsElements.map((el) => {
-        return el.getBoundingClientRect().width;
-      }),
-    );
+    const columnsElementsWidths = columnsElements.map((el) => el.getBoundingClientRect().width);
+
+    setInitialColumnWidths(columnsElementsWidths);
+
+    // Проверяем, что таблица отрисовалась корректно, и устанавливаем значения ширин колонок после 1го рендера
+    if (
+      columnsElements[0].getBoundingClientRect().left !==
+      columnsElements[columnsElements.length - 1].getBoundingClientRect().left
+    ) {
+      setResizedColumnWidths(columnsElementsWidths);
+    }
   }, [tableWidth]);
 
   const isSortedByColumn = (column: TableColumn<T>): boolean =>


### PR DESCRIPTION
## Описание изменений

Устанавливаем ширины колонок в таблице после первого рендера, чтобы таблица не ресайзилась сама в случаях фильтрации и lazy load'a

https://github.com/gazprom-neft/consta-uikit/issues/615

## Чек-лист

- [ ] PR: направлен в правильную ветку
- [ ] PR: назначен исполнитель PR и указаны нужные лейблы
- [ ] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] PR: есть описание изменений
- [ ] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются [переменные](../src/components/Theme)
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [ ] Коммиты: проименованы в соответствии с [правилами](https://consta-uikit.vercel.app/?path=/docs/common-develop-commits-style--page)
