### PR TITLE
feat(components): table. Вынес sortBy в props

### DIFF
--- a/src/components/Table/__mock__/data.mock.tsx
+++ b/src/components/Table/__mock__/data.mock.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Badge } from '../../Badge/Badge';
-import { Props as TableProps, TableFilters as Filters } from '../Table';
+import { Props as TableProps, TableFilters as Filters, TableRow } from '../Table';
 
 export const rows = [
   {
@@ -432,7 +432,7 @@ const badgeParams: React.ComponentProps<typeof Badge> = {
   size: 'm',
 };
 
-const tableWithTrafficLightDataRows = [
+const tableWithTrafficLightDataRows: TableRow[] = [
   {
     id: 'row1',
     field: 'Северный бур',

--- a/src/components/Table/__stories__/Table.mdx
+++ b/src/components/Table/__stories__/Table.mdx
@@ -6,6 +6,7 @@ import { Preview } from '@storybook/addon-docs/dist/blocks';
 
 - [Структура](#структура)
   - [Колонки](#колонки)
+  - [Сортировка](#сортировка)
   - [Строки](#строки)
   - [Фильтры](#фильтры)
   - [Заглушка](#заглушка)
@@ -60,6 +61,10 @@ import { Preview } from '@storybook/addon-docs/dist/blocks';
   },
 ];
 ```
+
+### Сортировка
+Стандартное поведение сортирует только строки. Через параметр `onSortBy` можно получить имя столбца и порядок сортировки,
+самостоятельно отсортировать данные и передать в `rows` [см примеры](#сортировка-по-времени-через-onsortby)
 
 ### Строки
 
@@ -211,6 +216,7 @@ type LazyLoad = { maxVisibleRows?: number; scrollableEl?: HTMLDivElement / Windo
 | [`borderBetweenColumns`](#границы)            | `boolean`                                           | false                                             | Отображение границ между колонками                 |
 | [`emptyRowsPlaceholder`](#заглушка)           | `React.ReactNode`                                   | -                                                 | Заглушка, показывается, когда в таблице нет данных |
 | [`onRowHover`](#выделить-строки)              | `OnRowHover`                                        | -                                                 | Функция которая сработает при наведении на строку  |
+| [`onSortBy`](#сортировка)                     | `onSortBy`                                          | sortByDefault                                     | Функция срабатывает при нажатии на иконку сортировки|
 | `className`                                   | `string`                                            | -                                                 | Дополнительный CSS-класс                           |
 | lazyLoad?                                     | `LazyLoad`                                          | `{ maxVisibleRows: 210; scrollableEl: tableRef }` | Включает виртуальную прокрутку в таблице           |
 
@@ -297,3 +303,70 @@ const App = () => {
   return <Table columns={columns} rows={rows} />;
 };
 ```
+
+
+### Сортировка по времени через onSortBy
+
+```tsx
+import React, {useState} from 'react';
+import { Table, SortByProps } from '@consta/uikit/Table';
+
+const data = [
+  {
+    id: 1,
+    date: new Date('Thu Dec 03 2020 14:23:13 GMT+0300 (Moscow Standard Time)')
+  },
+  {
+    id: 2,
+    date: new Date('Thu Dec 03 2020 14:04:13 GMT+0300 (Moscow Standard Time)')
+  },
+  {
+    id: 3,
+    date: new Date('Thu Dec 03 2020 14:55:13 GMT+0300 (Moscow Standard Time)')
+  },
+  {
+    id: 4,
+    date: new Date('Thu Dec 03 2020 14:12:13 GMT+0300 (Moscow Standard Time)')
+  },
+]
+
+const columns = [
+  {
+    title: `Id`,
+    accessor: `id`,
+    sortable: true,
+  },
+  {
+    title: `Дата`,
+    accessor: `date`,
+    sortable: true,
+  }
+]
+
+const App = () => {
+    const [sortSetting, setSortSetting] = useState<SortByProps<any> | null>(null)
+
+    const rows = data.sort((a, b) => {
+        if (sortSetting?.sortingBy === 'date') {
+          const [firstDate, secondDate] = sortSetting.sortOrder === 'asc' ? [a.date, b.date] : [b.date, a.date]
+          return firstDate.valueOf() - secondDate.valueOf()
+        }
+        return 0
+      })
+      .map((item) => ({
+      id: item.id.valueOf(),
+      date: item.date.toString(),
+    }))
+
+    return (
+      <Table
+        rows={rows}
+        columns={columns}
+        onSortBy={setSortSetting}
+      />
+    );
+};
+```
+
+
+

--- a/src/components/Table/__stories__/Table.stories.tsx
+++ b/src/components/Table/__stories__/Table.stories.tsx
@@ -1,6 +1,6 @@
 import './Table.stories.css';
 
-import React from 'react';
+import React, { useState } from 'react';
 import { boolean, number, object, select, text } from '@storybook/addon-knobs';
 
 import {
@@ -17,7 +17,7 @@ import { Button } from '../../Button/Button';
 import { Checkbox } from '../../Checkbox/Checkbox';
 import { Text } from '../../Text/Text';
 import { verticalAligns } from '../Cell/TableCell';
-import { Filters } from '../filtering';
+import { Filters, SortByProps } from '../filtering';
 import { Props, sizes, Table, TableColumn, TableRow, zebraStriped } from '../Table';
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
@@ -228,6 +228,62 @@ export const WithBigData = createStory(
   },
   {
     name: 'с большим количеством строк',
+  },
+);
+
+export const SortByData = createStory(
+  () => {
+    const [sortSetting, setSortSetting] = useState<SortByProps<any> | null>(null);
+    const data = [
+      {
+        id: 1,
+        date: new Date('Thu Dec 03 2020 14:23:13 GMT+0300 (Moscow Standard Time)'),
+      },
+      {
+        id: 2,
+        date: new Date('Thu Dec 03 2020 14:04:13 GMT+0300 (Moscow Standard Time)'),
+      },
+      {
+        id: 3,
+        date: new Date('Thu Dec 03 2020 14:55:13 GMT+0300 (Moscow Standard Time)'),
+      },
+      {
+        id: 4,
+        date: new Date('Thu Dec 03 2020 14:12:13 GMT+0300 (Moscow Standard Time)'),
+      },
+    ];
+
+    const rows = data
+      .sort((a, b) => {
+        if (sortSetting?.sortingBy === 'date') {
+          const [firstDate, secondDate] =
+            sortSetting.sortOrder === 'asc' ? [a.date, b.date] : [b.date, a.date];
+          return firstDate.valueOf() - secondDate.valueOf();
+        }
+        return 0;
+      })
+      .map((item) => ({
+        id: item.id.valueOf(),
+        date: item.date.toString(),
+      }));
+
+    const columns = [
+      {
+        title: `Id`,
+        accessor: `id`,
+        sortable: true,
+      },
+      {
+        title: `Дата`,
+        accessor: `date`,
+        sortable: true,
+      },
+    ];
+
+    return <Table rows={rows} columns={columns} onSortBy={setSortSetting} />;
+  },
+  {
+    name: 'сортировка по времени',
   },
 );
 

--- a/src/components/Table/filtering.ts
+++ b/src/components/Table/filtering.ts
@@ -11,6 +11,13 @@ export type Filters<T extends TableRow> = Array<{
   filterer: (value: any) => boolean;
 }>;
 
+export type SortByProps<T extends TableRow> = {
+  sortingBy: keyof T;
+  sortOrder: 'asc' | 'desc';
+};
+
+export type onSortBy<T extends TableRow> = (props: SortByProps<T> | null) => void;
+
 export type FieldSelectedValues = string[];
 
 export type SelectedFilters = { [field: string]: FieldSelectedValues | undefined };


### PR DESCRIPTION
## Описание изменений
Вынес функцию sortBy в props чтобы можно было задать свою кастомную сортировку.
Для задачи https://jira.csssr.io/browse/GDC-1050 нужна сортировка времени с датой. Думаю нет смысла держать логику сортировки в Table компоненте

## Чек-лист

- [ ] PR: направлен в правильную ветку
- [ ] PR: назначен исполнитель PR и указаны нужные лейблы
- [ ] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: прилинкованы затронутые issue и связанные PR
- [x] PR: есть описание изменений
- [ ] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [x] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются [переменные](../src/components/Theme)
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [ ] Коммиты: проименованы в соответствии с [правилами](https://consta-uikit.vercel.app/?path=/docs/common-develop-commits-style--page)
