### PR TITLE
fix(Table): parent width related child headers (#553)

### DIFF
--- a/src/components/Table/__tests__/helpers.test.ts
+++ b/src/components/Table/__tests__/helpers.test.ts
@@ -16,7 +16,7 @@ describe('getColumnsSize', () => {
   it('получение размера колонок', () => {
     const result = getColumnsSize([150, undefined]);
 
-    expect(result).toEqual('150px minmax(min-content, 1fr)');
+    expect(result).toEqual('150px minmax(min-content, 50%)');
   });
 });
 

--- a/src/components/Table/helpers.ts
+++ b/src/components/Table/helpers.ts
@@ -27,7 +27,7 @@ export type HeaderData<T extends TableRow> = {
 };
 
 export const getColumnsSize = (sizes: ColumnWidth[]): string => {
-  return sizes.map((s) => (s ? `${s}px` : 'minmax(min-content, 1fr)')).join(' ');
+  return sizes.map((s) => (s ? `${s}px` : `minmax(min-content, ${100 / sizes.length}%)`)).join(' ');
 };
 
 export const getColumnLeftOffset = ({


### PR DESCRIPTION
## Описание изменений

Пофикшена ширина родительского заголовка относительно детей (https://github.com/gazprom-neft/consta-uikit/issues/553)

<img width="856" alt="Снимок экрана 2020-12-17 в 12 59 53" src="https://user-images.githubusercontent.com/70316813/102474467-bc4f7600-4069-11eb-9634-d5dee072fbef.png">


## Чек-лист

- [ ] PR: направлен в правильную ветку
- [ ] PR: назначен исполнитель PR и указаны нужные лейблы
- [ ] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] PR: есть описание изменений
- [ ] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются [переменные](../src/components/Theme)
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [ ] Коммиты: проименованы в соответствии с [правилами](https://consta-uikit.vercel.app/?path=/docs/common-develop-commits-style--page)
