### PR TITLE
docs(sidebar): fix position bottom example

### DIFF
--- a/src/components/Sidebar/__stories__/examples/SidebarExample/SidebarExample.tsx
+++ b/src/components/Sidebar/__stories__/examples/SidebarExample/SidebarExample.tsx
@@ -255,7 +255,7 @@ export const SidebarExampleBottom = () => {
         className={cnSidebarExample('Sidebar')}
         isOpen={isSidebarOpen}
         onOverlayClick={() => setIsSidebarOpen(false)}
-        position="right"
+        position="bottom"
       >
         <Sidebar.Content className={cnSidebarExample('Content')}>
           <Text


### PR DESCRIPTION
## Описание изменений

Поменяла ошибку в документации: пример для position = bottom открывался справа. Теперь всё ок.
