### PR TITLE
feat(hooks): добавлена возможность получать размеры SVG элементов в хуке useComponentSiz

### DIFF
--- a/src/hooks/useComponentSize/useComponentSize.tsx
+++ b/src/hooks/useComponentSize/useComponentSize.tsx
@@ -5,18 +5,22 @@ type ComponentSize = {
   height: number;
 };
 
-const getElementSize = (el: HTMLElement | null): ComponentSize =>
-  el
-    ? {
-        width: el.offsetWidth,
-        height: el.offsetHeight,
-      }
-    : {
-        width: 0,
-        height: 0,
-      };
+const getElementSize = (el: HTMLElement | SVGGraphicsElement | null): ComponentSize => {
+  if (!el) {
+    return { width: 0, height: 0 };
+  }
 
-export function useComponentSize<T extends HTMLElement>(ref: React.RefObject<T>): ComponentSize {
+  const { width, height } = el.getBoundingClientRect();
+
+  return {
+    width: Math.floor(width),
+    height: Math.floor(height),
+  };
+};
+
+export function useComponentSize<T extends HTMLElement | SVGGraphicsElement>(
+  ref: React.RefObject<T>,
+): ComponentSize {
   const [componentSize, setComponentSize] = useState<ComponentSize>(
     getElementSize(ref && ref.current),
   );


### PR DESCRIPTION
## Описание изменений

Хук useComponentSize не умеет работать с SVG элементами, для некоторых графиков из `@consta/widgets` это необходимо.

## Чек-лист

- [ ] PR: направлен в правильную ветку
- [ ] PR: назначен исполнитель PR и указаны нужные лейблы
- [ ] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] PR: есть описание изменений
- [ ] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются [переменные](../src/components/Theme)
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [ ] Коммиты: проименованы в соответствии с [правилами](https://consta-uikit.vercel.app/?path=/docs/common-develop-commits-style--page)
