### PR TITLE
feat(Calendar): added useCurrentVisibleDate

### DIFF
--- a/src/components/Calendar/CalendarSlider/CalendarSlider.css
+++ b/src/components/Calendar/CalendarSlider/CalendarSlider.css
@@ -41,7 +41,7 @@
       }
 
       &_2 {
-        transform: translateX(calc(var(--year-width) - 0));
+        transform: translateX(calc(var(--year-width)));
       }
 
       &_3 {

--- a/src/components/Calendar/CalendarViewOneMonth/CalendarViewOneMonth.tsx
+++ b/src/components/Calendar/CalendarViewOneMonth/CalendarViewOneMonth.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { addMonths } from 'date-fns';
 import ruLocale from 'date-fns/locale/ru';
 
@@ -12,6 +12,7 @@ import {
   getDaysOfWeek,
   getHandleSelectDate,
   getMouthLabelWithYear,
+  useCurrentVisibleDate,
 } from '../helpers';
 
 export const cnCalendarViewOneMonth = cn('CalendarViewOneMonth');
@@ -24,12 +25,19 @@ export const CalendarViewOneMonth: CalendarViewComponent = React.forwardRef((pro
     maxDate,
     value,
     onChange,
-    currentVisibleDate: currentVisibleDateProp = new Date(),
+    currentVisibleDate: currentVisibleDateProp,
     events,
     locale = ruLocale,
     ...otherProps
   } = props;
-  const [currentVisibleDate, setCurrentVisibleDate] = useState(currentVisibleDateProp);
+
+  const [currentVisibleDate, setCurrentVisibleDate] = useCurrentVisibleDate({
+    currentVisibleDate: currentVisibleDateProp,
+    maxDate,
+    minDate,
+    value,
+  });
+
   const handleSelectDate = getHandleSelectDate({ type, minDate, maxDate, value, onChange });
   const daysOfMonth = getDaysOfMonth({
     date: currentVisibleDate,

--- a/src/components/Calendar/CalendarViewSlider/CalendarViewSlider.tsx
+++ b/src/components/Calendar/CalendarViewSlider/CalendarViewSlider.tsx
@@ -1,6 +1,6 @@
 import './CalendarViewSlider.css';
 
-import React, { useState } from 'react';
+import React from 'react';
 import { addMonths } from 'date-fns';
 import ruLocale from 'date-fns/locale/ru';
 
@@ -15,6 +15,7 @@ import {
   getDaysOfWeek,
   getHandleSelectDate,
   getMonthTitle,
+  useCurrentVisibleDate,
 } from '../helpers';
 
 export const cnCalendarViewSlider = cn('CalendarViewSlider');
@@ -33,7 +34,13 @@ export const CalendarViewSlider: CalendarViewComponent = React.forwardRef((props
     ...otherProps
   } = props;
 
-  const [currentVisibleDate, setCurrentVisibleDate] = useState(currentVisibleDateProp);
+  const [currentVisibleDate, setCurrentVisibleDate] = useCurrentVisibleDate({
+    currentVisibleDate: currentVisibleDateProp,
+    maxDate,
+    minDate,
+    value,
+  });
+
   const handleSelectDate = getHandleSelectDate({ type, minDate, maxDate, value, onChange });
   const daysOfMonth = getDaysOfMonth({
     date: currentVisibleDate,

--- a/src/components/Calendar/CalendarViewTwoMonths/CalendarViewTwoMonths.tsx
+++ b/src/components/Calendar/CalendarViewTwoMonths/CalendarViewTwoMonths.tsx
@@ -1,6 +1,6 @@
 import './CalendarViewTwoMonths.css';
 
-import React, { useState } from 'react';
+import React from 'react';
 import { addMonths } from 'date-fns';
 import ruLocale from 'date-fns/locale/ru';
 
@@ -14,6 +14,7 @@ import {
   getDaysOfWeek,
   getHandleSelectDate,
   getMouthLabelWithYear,
+  useCurrentVisibleDate,
 } from '../helpers';
 
 export const cnCalendarViewTwoMonths = cn('CalendarViewTwoMonths');
@@ -31,7 +32,13 @@ export const CalendarViewTwoMonths: CalendarViewComponent = React.forwardRef((pr
     locale = ruLocale,
     ...otherProps
   } = props;
-  const [currentVisibleDate, setCurrentVisibleDate] = useState(currentVisibleDateProp);
+
+  const [currentVisibleDate, setCurrentVisibleDate] = useCurrentVisibleDate({
+    currentVisibleDate: currentVisibleDateProp,
+    maxDate,
+    minDate,
+    value,
+  });
 
   const handleSelectDate = getHandleSelectDate({ type, minDate, maxDate, value, onChange });
 

--- a/src/components/Calendar/__stories__/Calendar.stories.tsx
+++ b/src/components/Calendar/__stories__/Calendar.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { boolean, date, select } from '@storybook/addon-knobs';
-import { addDays, endOfYear, Locale, startOfWeek, startOfYear } from 'date-fns';
+import { addDays, addMonths, endOfYear, Locale, startOfWeek, startOfYear } from 'date-fns';
 import enUSLocale from 'date-fns/locale/en-US';
 import esLocale from 'date-fns/locale/es';
 import ruLocale from 'date-fns/locale/ru';
@@ -49,17 +49,25 @@ export function Playground() {
     ? [startOfWeek(currentDay, { locale: ruLocale }), currentDay, addDays(currentDay, 2)]
     : undefined;
 
+  const [startDate, setStartDate] = useState<Date>(currentDay);
+
   return (
-    <Calendar
-      type={type}
-      value={value}
-      view={view}
-      onChange={({ value }) => setValue(value)}
-      minDate={new Date(minDate)}
-      maxDate={new Date(maxDate)}
-      events={events}
-      locale={getSizeByMap(localeMap, locale)}
-    />
+    <>
+      <button type="button" onClick={() => setStartDate(addMonths(startDate, 1))}>
+        ddd
+      </button>
+      <Calendar
+        type={type}
+        value={value}
+        view={view}
+        onChange={({ value }) => setValue(value)}
+        minDate={new Date(minDate)}
+        maxDate={new Date(maxDate)}
+        events={events}
+        locale={getSizeByMap(localeMap, locale)}
+        // currentVisibleDate={startDate}
+      />
+    </>
   );
 }
 

--- a/src/components/Calendar/__stories__/Calendar.stories.tsx
+++ b/src/components/Calendar/__stories__/Calendar.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { boolean, date, select } from '@storybook/addon-knobs';
-import { addDays, addMonths, endOfYear, Locale, startOfWeek, startOfYear } from 'date-fns';
+import { addDays, endOfYear, Locale, startOfWeek, startOfYear } from 'date-fns';
 import enUSLocale from 'date-fns/locale/en-US';
 import esLocale from 'date-fns/locale/es';
 import ruLocale from 'date-fns/locale/ru';
@@ -49,25 +49,17 @@ export function Playground() {
     ? [startOfWeek(currentDay, { locale: ruLocale }), currentDay, addDays(currentDay, 2)]
     : undefined;
 
-  const [startDate, setStartDate] = useState<Date>(currentDay);
-
   return (
-    <>
-      <button type="button" onClick={() => setStartDate(addMonths(startDate, 1))}>
-        ddd
-      </button>
-      <Calendar
-        type={type}
-        value={value}
-        view={view}
-        onChange={({ value }) => setValue(value)}
-        minDate={new Date(minDate)}
-        maxDate={new Date(maxDate)}
-        events={events}
-        locale={getSizeByMap(localeMap, locale)}
-        // currentVisibleDate={startDate}
-      />
-    </>
+    <Calendar
+      type={type}
+      value={value}
+      view={view}
+      onChange={({ value }) => setValue(value)}
+      minDate={new Date(minDate)}
+      maxDate={new Date(maxDate)}
+      events={events}
+      locale={getSizeByMap(localeMap, locale)}
+    />
   );
 }
 


### PR DESCRIPTION
issue -  #1192

## Описание изменений

Если есть `currentVisibleDate` то открываем календарь с этим месяцем
Если есть `value` то календарь открывается на том месяце на котором есть `value`
Если есть `minDate` и `maxDate` и текущая дата не входит в этот диапазон, то открываем календарь с месяцем из `minDate` 
Если `minDate && !maxDate && currentDate < minDateTime` то `minDate`
Если `!minDate && maxDate && currentDate > minDateTime` то `maxDate`

в остальных случаях `currentDate`

## Чек-лист

- [ ] PR: направлен в правильную ветку
- [ ] PR: назначен исполнитель PR и указаны нужные лейблы
- [ ] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] PR: есть описание изменений
- [ ] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются [переменные](../src/components/Theme)
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [ ] Коммиты: проименованы в соответствии с [правилами](https://consta-uikit.vercel.app/?path=/docs/common-develop-commits-style--page)
