### PR TITLE
feat(SnackBar): Add hideTimer props

### DIFF
--- a/src/components/SnackBar/Item/SnackBar-Item.tsx
+++ b/src/components/SnackBar/Item/SnackBar-Item.tsx
@@ -33,7 +33,7 @@ export const SnackBarItem: React.FC<SnackBarItemProps> = (props) => {
   const {
     onClose,
     autoClose,
-    hideTimer,
+    showProgress,
     icon: Icon,
     message,
     actions,
@@ -51,7 +51,8 @@ export const SnackBarItem: React.FC<SnackBarItemProps> = (props) => {
   const handleMouseEnter = () => setHover(true);
   const handleMouseLeave = () => setHover(false);
   const autoCloseTime = getAutoCloseTime(autoClose);
-  const hideAutoCloseTimer = !!hideTimer || !(isNumber(autoCloseTime) && autoCloseTime > 0);
+  const hideAutoCloseTimer =
+    showProgress === undefined || !(isNumber(autoCloseTime) && autoCloseTime > 0);
   const onAutoClose = (item: Item) => {
     if (onAutoCloseProp) {
       onAutoCloseProp(item);

--- a/src/components/SnackBar/Item/SnackBar-Item.tsx
+++ b/src/components/SnackBar/Item/SnackBar-Item.tsx
@@ -4,6 +4,7 @@ import './SnackBar-Item.css';
 import React, { useEffect, useState } from 'react';
 
 import { IconClose } from '../../../icons/IconClose/IconClose';
+import { isNumber } from '../../../utils/type-guards';
 import { Button } from '../../Button/Button';
 import { Text } from '../../Text/Text';
 import { cnTheme } from '../../Theme/Theme';
@@ -32,6 +33,7 @@ export const SnackBarItem: React.FC<SnackBarItemProps> = (props) => {
   const {
     onClose,
     autoClose,
+    hideTimer,
     icon: Icon,
     message,
     actions,
@@ -49,6 +51,7 @@ export const SnackBarItem: React.FC<SnackBarItemProps> = (props) => {
   const handleMouseEnter = () => setHover(true);
   const handleMouseLeave = () => setHover(false);
   const autoCloseTime = getAutoCloseTime(autoClose);
+  const hideAutoCloseTimer = !!hideTimer || !(isNumber(autoCloseTime) && autoCloseTime > 0);
   const onAutoClose = (item: Item) => {
     if (onAutoCloseProp) {
       onAutoCloseProp(item);
@@ -85,9 +88,10 @@ export const SnackBarItem: React.FC<SnackBarItemProps> = (props) => {
           onMount={handleMountTimer}
           onTimeIsOver={handleTimeIsOver}
           startTime={autoCloseTime}
+          hidden={hideAutoCloseTimer}
         />
       )}
-      {!autoCloseTime && Icon && <Icon className={cnSnackBar('Icon')} size="m" />}
+      {hideAutoCloseTimer && Icon && <Icon className={cnSnackBar('Icon')} size="m" />}
       <div className={cnSnackBar('Content')}>
         {message && (
           <Text className={cnSnackBar('Message')} lineHeight="s">

--- a/src/components/SnackBar/SnackBar.tsx
+++ b/src/components/SnackBar/SnackBar.tsx
@@ -25,6 +25,7 @@ export type Item = {
   message?: string | number;
   status?: SnackBarItemStatus;
   autoClose?: boolean | number;
+  hideTimer?: boolean;
   icon?: React.FC<IconProps>;
   actions?: SnackBarPropItemAction[];
   onClose?: (item: Item) => void;

--- a/src/components/SnackBar/SnackBar.tsx
+++ b/src/components/SnackBar/SnackBar.tsx
@@ -25,7 +25,7 @@ export type Item = {
   message?: string | number;
   status?: SnackBarItemStatus;
   autoClose?: boolean | number;
-  hideTimer?: boolean;
+  showProgress?: 'timer';
   icon?: React.FC<IconProps>;
   actions?: SnackBarPropItemAction[];
   onClose?: (item: Item) => void;

--- a/src/components/SnackBar/Timer/SnackBar-Timer.tsx
+++ b/src/components/SnackBar/Timer/SnackBar-Timer.tsx
@@ -12,13 +12,14 @@ export type SnackBarTimerProps = {
   onMount: SnackBarTimerPropOnMount;
   onTimeIsOver: () => void;
   startTime: number;
+  hidden?: boolean;
 };
 
 const interval = 1000;
 
 export const SnackBarTimer: React.FC<SnackBarTimerProps> = (props) => {
   const [running, setRunning] = useState<boolean>(false);
-  const { onMount, onTimeIsOver, startTime: startTimeprop } = props;
+  const { onMount, onTimeIsOver, startTime: startTimeprop, hidden } = props;
   const startTime = startTimeprop * interval;
   const { time, start, pause, isRunning } = useTimer({
     endTime: 0,
@@ -38,6 +39,10 @@ export const SnackBarTimer: React.FC<SnackBarTimerProps> = (props) => {
 
   const progress = running ? ((time - interval) / startTime) * 100 : (time / startTime) * 100;
   const seconds = time ? time / interval : 0;
+
+  if (hidden) {
+    return null;
+  }
 
   return (
     <Timer

--- a/src/components/SnackBar/__stories__/SnackBar.docs.mdx
+++ b/src/components/SnackBar/__stories__/SnackBar.docs.mdx
@@ -58,7 +58,12 @@ import { SnackBarExampleButtons } from './examples/SnackBarExampleButtons/SnackB
 **Не удалять**. Если пользователь, нажмет на кнопку. Если нет, сообщение само закроется
 по таймеру.
 
-Таймер можно добавить с помощью `autoClose`, а если вам нужна иконка, используйте этот параметр вместе с `hideTimer`.
+Таймер можно добавить с помощью `autoClose`, а с помощью `showProgress` можно выбрать его вид.
+
+| Значение `showProgress` | По умолчанию | Описание                                                                              |
+| ----------------------- | ------------ | ------------------------------------------------------------------------------------- |
+| `"timer"`               |              | Визуально отображает радиальный таймер (если указана иконка, то он заместит её собой) |
+| `undefined`             | +            | Работает только логика таймера. Сам таймер скрыт.                                     |
 
 <SnackBarExampleTimer />
 
@@ -70,7 +75,7 @@ type Item = {
   message?: string | number;
   status?: 'success' | 'warning' | 'alert' | 'normal';
   autoClose?: boolean | number;
-  hideTimer?: boolean;
+  showProgress?: 'timer';
   icon?: React.FC<IconProps>;
   actions?: {
     label: string | number;

--- a/src/components/SnackBar/__stories__/SnackBar.docs.mdx
+++ b/src/components/SnackBar/__stories__/SnackBar.docs.mdx
@@ -9,7 +9,7 @@ import { SnackBarExampleButtons } from './examples/SnackBarExampleButtons/SnackB
 
 Используется для мгновенных уведомлений.
 
-Снекбар (в отличие от [информера](?path=/docs/components-informer--playground))
+Снекбар (в отличие от [информера](/?path=/docs/components-informer--playground))
 всегда перекрывает основное содержимое, выносится в отдельный слой интерфейса
 и сопровождается анимацией. На него будет направлено всё внимание пользователя.
 
@@ -37,7 +37,7 @@ import { SnackBarExampleButtons } from './examples/SnackBarExampleButtons/SnackB
 
 ## Иконка
 
-Добавьте любую из [библиотеки иконок](?path=/story/components-icons--playground) с помощью свойства `icon`.
+Добавьте любую из [библиотеки иконок](/?path=/story/components-icons--playground) с помощью свойства `icon`.
 
 <SnackBarExampleIcon />
 
@@ -58,7 +58,7 @@ import { SnackBarExampleButtons } from './examples/SnackBarExampleButtons/SnackB
 **Не удалять**. Если пользователь, нажмет на кнопку. Если нет, сообщение само закроется
 по таймеру.
 
-Таймер можно добавить с помощью `autoClose`.
+Таймер можно добавить с помощью `autoClose`, а если вам нужна иконка, используйте этот параметр вместе с `hideTimer`.
 
 <SnackBarExampleTimer />
 
@@ -70,6 +70,7 @@ type Item = {
   message?: string | number;
   status?: 'success' | 'warning' | 'alert' | 'normal';
   autoClose?: boolean | number;
+  hideTimer?: boolean;
   icon?: React.FC<IconProps>;
   actions?: {
     label: string | number;

--- a/src/components/SnackBar/__stories__/SnackBar.stories.tsx
+++ b/src/components/SnackBar/__stories__/SnackBar.stories.tsx
@@ -28,6 +28,7 @@ const defaultKnobs = () => ({
   withActionButtons: boolean('withActionButtons', false),
   withAutoClose: boolean('withAutoClose', false),
   withCloseButton: boolean('withCloseButton', true),
+  withHiddenTimer: boolean('withHiddenTimer', false),
 });
 
 const getItemIconByStatus = (status: SnackBarItemStatus): React.FC<IconProps> | undefined => {
@@ -53,7 +54,13 @@ function reducer(state: State, action: Action) {
 }
 
 export function Playground() {
-  const { withIcon, withActionButtons, withAutoClose, withCloseButton } = defaultKnobs();
+  const {
+    withIcon,
+    withActionButtons,
+    withAutoClose,
+    withHiddenTimer,
+    withCloseButton,
+  } = defaultKnobs();
   const [items, dispatchItems] = React.useReducer(reducer, []);
   const generateHandleAdd = (status: SnackBarItemStatus) => () => {
     const key = items.length + 1;
@@ -62,6 +69,7 @@ export function Playground() {
       message: `Сообщение о каком-то событии - ${key}`,
       status,
       ...(withAutoClose && { autoClose: 5 }),
+      ...(withHiddenTimer && { hideTimer: true }),
       ...(withIcon && { icon: getItemIconByStatus(status) }),
       ...(withActionButtons && {
         actions: [

--- a/src/components/SnackBar/__stories__/SnackBar.stories.tsx
+++ b/src/components/SnackBar/__stories__/SnackBar.stories.tsx
@@ -28,7 +28,7 @@ const defaultKnobs = () => ({
   withActionButtons: boolean('withActionButtons', false),
   withAutoClose: boolean('withAutoClose', false),
   withCloseButton: boolean('withCloseButton', true),
-  withHiddenTimer: boolean('withHiddenTimer', false),
+  withShowProgress: boolean('withShowProgress', false),
 });
 
 const getItemIconByStatus = (status: SnackBarItemStatus): React.FC<IconProps> | undefined => {
@@ -58,7 +58,7 @@ export function Playground() {
     withIcon,
     withActionButtons,
     withAutoClose,
-    withHiddenTimer,
+    withShowProgress,
     withCloseButton,
   } = defaultKnobs();
   const [items, dispatchItems] = React.useReducer(reducer, []);
@@ -69,7 +69,7 @@ export function Playground() {
       message: `Сообщение о каком-то событии - ${key}`,
       status,
       ...(withAutoClose && { autoClose: 5 }),
-      ...(withHiddenTimer && { hideTimer: true }),
+      ...(withShowProgress && { showProgress: 'timer' }),
       ...(withIcon && { icon: getItemIconByStatus(status) }),
       ...(withActionButtons && {
         actions: [

--- a/src/components/SnackBar/__stories__/examples/SnackBarExampleTimer/SnackBarExampleTimer.tsx
+++ b/src/components/SnackBar/__stories__/examples/SnackBarExampleTimer/SnackBarExampleTimer.tsx
@@ -40,7 +40,7 @@ export const SnackBarExampleTimer: React.FC = () => {
   const [items, dispatchItems] = useReducer<
     React.Reducer<Item[], { type: 'add' | 'remove'; item: Item; key?: number | string }>
   >(reducer, []);
-  const generateHandleAdd = (status: SnackBarItemStatus) => () => {
+  const generateHandleAdd = (status: SnackBarItemStatus, hideTimer?: boolean) => () => {
     const key = items.length + 1;
     const item: Item = {
       key,
@@ -49,12 +49,14 @@ export const SnackBarExampleTimer: React.FC = () => {
       icon: getItemIconByStatus(status),
       onClose: () => dispatchItems({ type: 'remove', item, key }),
       autoClose: 5,
+      hideTimer,
     };
     dispatchItems({ type: 'add', item });
   };
 
   const handleAlertAdd = generateHandleAdd('alert');
   const handleNormalAdd = generateHandleAdd('normal');
+  const handleHiddenTimerAdd = generateHandleAdd('normal', true);
 
   React.useEffect(() => handleNormalAdd(), []);
 
@@ -72,6 +74,12 @@ export const SnackBarExampleTimer: React.FC = () => {
           iconLeft={IconAdd}
           label="Тревожный таймер"
           onClick={handleAlertAdd}
+        />
+        <Button
+          className={cnSnackBarExampleTimer('ButtonAdd')}
+          iconLeft={IconAdd}
+          label="Скрытый таймер + иконка"
+          onClick={handleHiddenTimerAdd}
         />
       </div>
       <SnackBar className={cnSnackBarExampleTimer('SnackBar')} items={items} />

--- a/src/components/SnackBar/__stories__/examples/SnackBarExampleTimer/SnackBarExampleTimer.tsx
+++ b/src/components/SnackBar/__stories__/examples/SnackBarExampleTimer/SnackBarExampleTimer.tsx
@@ -40,7 +40,7 @@ export const SnackBarExampleTimer: React.FC = () => {
   const [items, dispatchItems] = useReducer<
     React.Reducer<Item[], { type: 'add' | 'remove'; item: Item; key?: number | string }>
   >(reducer, []);
-  const generateHandleAdd = (status: SnackBarItemStatus, hideTimer?: boolean) => () => {
+  const generateHandleAdd = (status: SnackBarItemStatus, showProgress?: 'timer') => () => {
     const key = items.length + 1;
     const item: Item = {
       key,
@@ -49,14 +49,14 @@ export const SnackBarExampleTimer: React.FC = () => {
       icon: getItemIconByStatus(status),
       onClose: () => dispatchItems({ type: 'remove', item, key }),
       autoClose: 5,
-      hideTimer,
+      showProgress,
     };
     dispatchItems({ type: 'add', item });
   };
 
-  const handleAlertAdd = generateHandleAdd('alert');
-  const handleNormalAdd = generateHandleAdd('normal');
-  const handleHiddenTimerAdd = generateHandleAdd('normal', true);
+  const handleAlertAdd = generateHandleAdd('alert', 'timer');
+  const handleNormalAdd = generateHandleAdd('normal', 'timer');
+  const handleHiddenTimerAdd = generateHandleAdd('normal');
 
   React.useEffect(() => handleNormalAdd(), []);
 


### PR DESCRIPTION
Closes #972

## Описание изменений

- Изменено поведение по умолчанию.

По умолчанию, если указать `autoClose`, но не указывать `showProgress`, таймер будет невидимым.

Если использовать `showProgress`, то таймер будет работать без визуального отображения, а иконка будет видна, как без `autoClose`.

Если не использовать `hideTimer`, то поведение будет таким-же, как и раньше.


> # ПОСЛЕ РЕВЬЮ
> - Изменено поведение по умолчанию.
> 
> По умолчанию, если указать `autoClose`, но не указывать `showProgress`, таймер будет невидимым.
> Если указать `showProgress="timer"`, то таймер будет работать как раньше. Таймер так-же отображается вместо иконки, если включены оба.

## Чек-лист

- [ ] PR: направлен в правильную ветку
- [ ] PR: назначен исполнитель PR и указаны нужные лейблы
- [ ] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] PR: есть описание изменений
- [ ] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются [переменные](../src/components/Theme)
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [ ] Коммиты: проименованы в соответствии с [правилами](https://consta-uikit.vercel.app/?path=/docs/common-develop-commits-style--page)
