### PR TITLE
feat(Table): Add getComparisonValue function

### DIFF
--- a/src/components/Table/__stories__/Table.docs.mdx
+++ b/src/components/Table/__stories__/Table.docs.mdx
@@ -467,6 +467,8 @@ const rows = [
 const App = () => <Table columns={colums} rows={rows} />;
 ```
 
+Посмотреть этот пример в работе можно [ТУТ](/?path=/story/components-table--with-merged-by-custom-callback-cells).
+
 ### Со своим текстом, если нет данных
 
 ```tsx

--- a/src/components/Table/__stories__/Table.docs.mdx
+++ b/src/components/Table/__stories__/Table.docs.mdx
@@ -268,6 +268,14 @@ import { TableFilterContainer } from '@consta/uikit/Table';
 
 Отдельно настраивается выравниваются для заголовков — `verticalHeaderAlign`.
 
+### Объединение ячеек
+
+Если вам нужно объединять ячейки с одинаковым содержимым, вы можете указать свойство `mergeCells: true` в объекте той колонки, в которой хотите объединять ячейки.
+Объединение происходит для тех ячеек, которые идут подряд и для их значений справедливо условие `firstValue === secondValue`.
+
+Если в ваших ячейках находятся **не** стандартные данные или вам нужно как-то иначе их сравнивать (например сравнить строки с разным регистром), вы можете использовать колбек `getComparisonValue`.
+Он принимает в себя значение текущей ячейки и должен возвращать строку или число.
+
 ## Свойства
 
 ```ts
@@ -283,6 +291,8 @@ type Column = {
   sortByField?: string;
   sortFn?: (a: FieldValue, b: FieldValue) => number;
   renderCell?: (row: Row) => React.ReactNode;
+  mergeCell?: boolean;
+  getComparisonValue?: (cell: Row[Column.accessor]) => number | string; // cell - значение из ячейки
 };
 
 type Row = {

--- a/src/components/Table/__stories__/Table.docs.mdx
+++ b/src/components/Table/__stories__/Table.docs.mdx
@@ -266,7 +266,7 @@ import { TableFilterContainer } from '@consta/uikit/Table';
 У этого свойства три значения: `'center', 'top', 'bottom'`. По умолчанию содержимое ячеек
 выравнивается по верхнему краю.
 
-Отдельно настраивается выравниваются для заголовков — `verticalHeaderAlign`.
+Отдельно настраивается выравнивания для заголовков — `verticalHeaderAlign`.
 
 ### Объединение ячеек
 
@@ -274,7 +274,7 @@ import { TableFilterContainer } from '@consta/uikit/Table';
 Объединение происходит для тех ячеек, которые идут подряд и для их значений справедливо условие `firstValue === secondValue`.
 
 Если в ваших ячейках находятся **не** стандартные данные или вам нужно как-то иначе их сравнивать (например сравнить строки с разным регистром), вы можете использовать колбек `getComparisonValue`.
-Он принимает в себя значение текущей ячейки и должен возвращать строку или число.
+Он принимает в себя значение текущей ячейки и должен возвращать строку или число по которым произойдет сравнение.
 
 ## Свойства
 
@@ -303,7 +303,7 @@ type Row = {
 type FilterComponentProps = {
   onConfirm: (value: any) => void;
   onCancel: () => void;
-  filterValue?: any
+  filterValue?: any;
 } & Record<string, unknown>;
 
 type Filter = {
@@ -311,18 +311,21 @@ type Filter = {
   name: string;
   field: string;
   filterer: (value: any, filterValue?: any) => boolean;
-} & ({ component?: never } | {
-  component: {
-    name: React.FC<FilterComponentProps>;
-    props?: Omit<FilterComponentProps, 'onConfirm' | 'filterValue'>;
-  }
-});
+} & (
+  | { component?: never }
+  | {
+      component: {
+        name: React.FC<FilterComponentProps>;
+        props?: Omit<FilterComponentProps, 'onConfirm' | 'filterValue'>;
+      };
+    }
+);
 
 type OnRowHover = ({ id, e }: { id: string | undefined; e: React.MouseEvent }) => void;
 
 type onRowClick = ({ id, e }: { id: string; e: React.MouseEvent }) => void;
 
-type LazyLoad = { maxVisibleRows?: number; scrollableEl?: HTMLDivElement / Window; }
+type LazyLoad = { maxVisibleRows?: number; scrollableEl?: HTMLDivElement | Window };
 // maxVisibleRows - количество строк
 // scrollableEl - элемент с onScroll listener
 ```
@@ -421,6 +424,47 @@ const rows = [
 const App = () => {
   return <Table columns={columns} rows={rows} />;
 };
+```
+
+### Со своей функцией генерации признака объединения
+
+Расширенный пример можно найти [ТУТ](https://github.com/gazprom-neft/consta-uikit/blob/master/src/components/Table/__stories__/Table.stories.tsx) в переменной `WithMergedByCustomCallbackCells`.
+
+```tsx
+import React from 'react';
+import { Table } from '@consta/uikit/Table';
+import { Checkbox } from '@consta/uikit/Checkbox';
+
+const colums = [
+  {
+    title: 'Операция подтверждена',
+    accessor: 'operationConfirmed',
+    mergeCells: true,
+    getComparisonValue: ({ owner, viewed }) => `${owner}-${viewed}`,
+    renderCell: ({ operationConfirmed: { viewed } }) => <Checkbox checked={viewed} />,
+  },
+];
+
+const rows = [
+  {
+    id: '1',
+    operationConfirmed: { owner: 'user', viewed: false },
+  },
+  {
+    id: '2',
+    operationConfirmed: { owner: 'user', viewed: false },
+  },
+  {
+    id: '3',
+    operationConfirmed: { owner: 'user', viewed: true },
+  },
+  {
+    id: '4',
+    operationConfirmed: { owner: 'admin', viewed: true },
+  },
+];
+
+const App = () => <Table columns={colums} rows={rows} />;
 ```
 
 ### Со своим текстом, если нет данных

--- a/src/components/Table/__stories__/Table.stories.tsx
+++ b/src/components/Table/__stories__/Table.stories.tsx
@@ -342,6 +342,66 @@ export const WithMergedCells = createStory(
   },
 );
 
+export const WithMergedByCustomCallbackCells = createStory(
+  () => {
+    const getRandomCase = (e: string) =>
+      e
+        .split('')
+        .map((chr) => (Math.round(Math.random()) ? chr.toLowerCase() : chr.toUpperCase()))
+        .join('');
+    return (
+      <Table
+        {...getKnobs({
+          borderBetweenColumns: true,
+          borderBetweenRows: true,
+          columns: [
+            {
+              title: 'ID',
+              accessor: 'id',
+              align: 'left',
+            },
+            {
+              title: 'Текст разного регистра',
+              accessor: 'randomCaseText',
+              mergeCells: true,
+              getComparisonValue: (cell: string) => cell.toLowerCase(),
+            },
+          ],
+          rows: [
+            {
+              id: '1',
+              randomCaseText: 'Текст',
+            },
+            {
+              id: '2',
+              randomCaseText: getRandomCase('Текст'),
+            },
+            {
+              id: '3',
+              randomCaseText: getRandomCase('Текст'),
+            },
+            {
+              id: '4',
+              randomCaseText: getRandomCase('Текст'),
+            },
+            {
+              id: '5',
+              randomCaseText: 'Строчка',
+            },
+            {
+              id: '6',
+              randomCaseText: getRandomCase('Строчка'),
+            },
+          ],
+        })}
+      />
+    );
+  },
+  {
+    name: 'с объединёнными кастомной функцией ячейками',
+  },
+);
+
 export const withCustomFilters = createStory(
   () => {
     return (

--- a/src/components/Table/__stories__/Table.stories.tsx
+++ b/src/components/Table/__stories__/Table.stories.tsx
@@ -344,11 +344,27 @@ export const WithMergedCells = createStory(
 
 export const WithMergedByCustomCallbackCells = createStory(
   () => {
-    const getRandomCase = (e: string) =>
-      e
-        .split('')
-        .map((chr) => (Math.round(Math.random()) ? chr.toLowerCase() : chr.toUpperCase()))
-        .join('');
+    const ADMIN_INDEXES = [3, 4, 7];
+    const USERS_COUNT = 12;
+
+    const checkedRow: { [key: string]: boolean } = new Array(USERS_COUNT)
+      .fill(false)
+      .reduce((previous, _, index) => {
+        return {
+          ...previous,
+          [`${index + 1}`]: !Math.round(Math.random()),
+        };
+      }, {});
+
+    const generateRowBase = (id: string, owner: string, viewed: boolean) => ({
+      id,
+      owner,
+      operationConfirmed: {
+        owner,
+        viewed,
+      },
+    });
+
     return (
       <Table
         {...getKnobs({
@@ -361,38 +377,28 @@ export const WithMergedByCustomCallbackCells = createStory(
               align: 'left',
             },
             {
-              title: 'Текст разного регистра',
-              accessor: 'randomCaseText',
+              title: 'Инициатор операции',
+              accessor: 'owner',
               mergeCells: true,
-              getComparisonValue: (cell: string) => cell.toLowerCase(),
+            },
+            {
+              title: 'Операция подтверждена',
+              accessor: 'operationConfirmed',
+              mergeCells: true,
+              getComparisonValue: ({ owner, viewed }) => `${owner}-${viewed}`,
+              renderCell: ({ operationConfirmed: { viewed } }) => <Checkbox checked={viewed} />,
             },
           ],
-          rows: [
-            {
-              id: '1',
-              randomCaseText: 'Текст',
-            },
-            {
-              id: '2',
-              randomCaseText: getRandomCase('Текст'),
-            },
-            {
-              id: '3',
-              randomCaseText: getRandomCase('Текст'),
-            },
-            {
-              id: '4',
-              randomCaseText: getRandomCase('Текст'),
-            },
-            {
-              id: '5',
-              randomCaseText: 'Строчка',
-            },
-            {
-              id: '6',
-              randomCaseText: getRandomCase('Строчка'),
-            },
-          ],
+          rows: Object.keys(checkedRow).map((id, index) => {
+            const isAuto = ADMIN_INDEXES.includes(index);
+            return {
+              ...generateRowBase(
+                id,
+                `${isAuto ? 'admin' : 'user'}`,
+                isAuto ? true : checkedRow[id],
+              ),
+            };
+          }),
         })}
       />
     );

--- a/src/components/Table/__stories__/Table.stories.tsx
+++ b/src/components/Table/__stories__/Table.stories.tsx
@@ -367,38 +367,32 @@ export const WithMergedByCustomCallbackCells = createStory(
 
     return (
       <Table
-        {...getKnobs({
-          borderBetweenColumns: true,
-          borderBetweenRows: true,
-          columns: [
-            {
-              title: 'ID',
-              accessor: 'id',
-              align: 'left',
-            },
-            {
-              title: 'Инициатор операции',
-              accessor: 'owner',
-              mergeCells: true,
-            },
-            {
-              title: 'Операция подтверждена',
-              accessor: 'operationConfirmed',
-              mergeCells: true,
-              getComparisonValue: ({ owner, viewed }) => `${owner}-${viewed}`,
-              renderCell: ({ operationConfirmed: { viewed } }) => <Checkbox checked={viewed} />,
-            },
-          ],
-          rows: Object.keys(checkedRow).map((id, index) => {
-            const isAuto = ADMIN_INDEXES.includes(index);
-            return {
-              ...generateRowBase(
-                id,
-                `${isAuto ? 'admin' : 'user'}`,
-                isAuto ? true : checkedRow[id],
-              ),
-            };
-          }),
+        borderBetweenColumns
+        borderBetweenRows
+        columns={[
+          {
+            title: 'ID',
+            accessor: 'id',
+            align: 'left',
+          },
+          {
+            title: 'Инициатор операции',
+            accessor: 'owner',
+            mergeCells: true,
+          },
+          {
+            title: 'Операция подтверждена',
+            accessor: 'operationConfirmed',
+            mergeCells: true,
+            getComparisonValue: ({ owner, viewed }) => `${owner}-${viewed}`,
+            renderCell: ({ operationConfirmed: { viewed } }) => <Checkbox checked={viewed} />,
+          },
+        ]}
+        rows={Object.keys(checkedRow).map((id, index) => {
+          const isAuto = ADMIN_INDEXES.includes(index);
+          return {
+            ...generateRowBase(id, `${isAuto ? 'admin' : 'user'}`, isAuto ? true : checkedRow[id]),
+          };
         })}
       />
     );


### PR DESCRIPTION
Closes #987

## Описание изменений
Добавил возможность указать свою функцию генерации значения которое сравнивается при объединении строк.
Исправил функцию `getTableCellProps`, т.к. в ней происходили лишние проходы цикла

## Чек-лист

- [ ] PR: направлен в правильную ветку
- [ ] PR: назначен исполнитель PR и указаны нужные лейблы
- [ ] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] PR: есть описание изменений
- [ ] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются [переменные](../src/components/Theme)
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [ ] Коммиты: проименованы в соответствии с [правилами](https://consta-uikit.vercel.app/?path=/docs/common-develop-commits-style--page)
