### PR TITLE
fix(SnackBar): fix bug with not working autoclose in playground

### DIFF
--- a/src/components/SnackBar/__stories__/SnackBar.stories.tsx
+++ b/src/components/SnackBar/__stories__/SnackBar.stories.tsx
@@ -68,7 +68,10 @@ export function Playground() {
       key,
       message: `Сообщение о каком-то событии - ${key}`,
       status,
-      ...(withAutoClose && { autoClose: 5 }),
+      ...(withAutoClose && {
+        autoClose: 5,
+        onAutoClose: () => dispatchItems({ type: 'remove', key }),
+      }),
       ...(withShowProgress && { showProgress: 'timer' }),
       ...(withIcon && { icon: getItemIconByStatus(status) }),
       ...(withActionButtons && {


### PR DESCRIPTION
issue #1572

## Описание изменений

* Исправлен баг в сторибуке связанный с тем что при выключенном отображении кнопки закрытия и включенном автозакрытии элемент не пропадал. 

## Чек-лист

- [ ] PR: направлен в правильную ветку
- [ ] PR: назначен исполнитель PR и указаны нужные лейблы
- [ ] PR: проверен diff, ничего лишнего в PR не попало
- [ ] PR: прилинкованы затронутые issue и связанные PR
- [ ] PR: есть описание изменений
- [ ] JS: нет варнингов и ошибок в консоли браузера
- [ ] Тесты: новый функционал и исправленные баги покрыты тестами
- [ ] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [ ] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются [переменные](../src/components/Theme)
- [ ] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [ ] Коммиты: проименованы в соответствии с [правилами](https://consta-uikit.vercel.app/?path=/docs/common-develop-commits-style--page)
