### PR TITLE
feat(components): added new option for table, filtericon, you can add…

### DIFF
--- a/src/components/Table/Header/TableHeader.css
+++ b/src/components/Table/Header/TableHeader.css
@@ -57,6 +57,10 @@
     right: calc(var(--half-cell-padding-horizontal) + var(--resizer-width));
     display: flex;
 
+    &_control {
+      margin-right: var(--space-xs);
+    }
+
     &_verticalAlign_bottom {
       bottom: var(--cell-padding-vertical);
       transform: translateY(calc((var(--control-height-xs) - var(--graphics-size-s)) / 2));

--- a/src/components/Table/Header/TableHeader.css
+++ b/src/components/Table/Header/TableHeader.css
@@ -57,10 +57,6 @@
     right: calc(var(--half-cell-padding-horizontal) + var(--resizer-width));
     display: flex;
 
-    &_control {
-      margin-right: var(--space-xs);
-    }
-
     &_verticalAlign_bottom {
       bottom: var(--cell-padding-vertical);
       transform: translateY(calc((var(--control-height-xs) - var(--graphics-size-s)) / 2));

--- a/src/components/Table/Header/TableHeader.tsx
+++ b/src/components/Table/Header/TableHeader.tsx
@@ -128,7 +128,7 @@ export const TableHeader = <T extends TableRow>({
   };
 
   const control = (column: Header<T> & ColumnMetaData): React.ReactNode => {
-    if (!column.isFilterActive && column.control) {
+    if (column.control) {
       return <div className={cnTableHeader('Buttons_control')}>{column.control({ column })}</div>;
     }
 
@@ -190,12 +190,9 @@ export const TableHeader = <T extends TableRow>({
                 className={cnTableHeader('Buttons', {
                   isSortingActive: column.isSortingActive,
                   isFilterActive: column.isFilterActive,
-                  isControlActive: Boolean(column.control),
                   verticalAlign: headerVerticalAlign,
                 })}
               >
-                {control(column)}
-
                 {column.sortable && (
                   <Button
                     size="xs"
@@ -209,6 +206,8 @@ export const TableHeader = <T extends TableRow>({
                 )}
 
                 {getFilterPopover(column)}
+
+                {control(column)}
               </div>
             </TableCell>
           );

--- a/src/components/Table/Header/TableHeader.tsx
+++ b/src/components/Table/Header/TableHeader.tsx
@@ -129,7 +129,7 @@ export const TableHeader = <T extends TableRow>({
 
   const control = (column: Header<T> & ColumnMetaData): React.ReactNode => {
     if (column.control) {
-      return <div className={cnTableHeader('Buttons_control')}>{column.control({ column })}</div>;
+      return <div className={cnTableHeader('Сontrol')}>{column.control({ column })}</div>;
     }
 
     return null;

--- a/src/components/Table/Header/TableHeader.tsx
+++ b/src/components/Table/Header/TableHeader.tsx
@@ -90,7 +90,7 @@ export const TableHeader = <T extends TableRow>({
   };
 
   const getFilterPopover = (column: Header<T> & ColumnMetaData): React.ReactNode => {
-    if (!filters || !column.accessor) {
+    if (!filters || !column.accessor || column.filterIcon) {
       return null;
     }
     const curFilter = filters.find(({ field }) => field === column.accessor);
@@ -125,6 +125,14 @@ export const TableHeader = <T extends TableRow>({
         )}
       </TableFilterTooltip>
     ) : null;
+  };
+
+  const filterIcon = (column: Header<T> & ColumnMetaData): React.ReactNode => {
+    if (!column.isFilterActive && column.filterIcon) {
+      return column.filterIcon;
+    }
+
+    return null;
   };
 
   return (
@@ -177,13 +185,17 @@ export const TableHeader = <T extends TableRow>({
               }
             >
               {column.title}
+
               <div
                 className={cnTableHeader('Buttons', {
                   isSortingActive: column.isSortingActive,
                   isFilterActive: column.isFilterActive,
+                  isFilterIconActive: Boolean(column.filterIcon),
                   verticalAlign: headerVerticalAlign,
                 })}
               >
+                {filterIcon(column)}
+
                 {column.sortable && (
                   <Button
                     size="xs"
@@ -195,6 +207,7 @@ export const TableHeader = <T extends TableRow>({
                     className={cnTableHeader('Icon', { type: 'sort' })}
                   />
                 )}
+
                 {getFilterPopover(column)}
               </div>
             </TableCell>

--- a/src/components/Table/Header/TableHeader.tsx
+++ b/src/components/Table/Header/TableHeader.tsx
@@ -90,7 +90,7 @@ export const TableHeader = <T extends TableRow>({
   };
 
   const getFilterPopover = (column: Header<T> & ColumnMetaData): React.ReactNode => {
-    if (!filters || !column.accessor || column.filterIcon) {
+    if (!filters || !column.accessor || column.control) {
       return null;
     }
     const curFilter = filters.find(({ field }) => field === column.accessor);
@@ -128,8 +128,8 @@ export const TableHeader = <T extends TableRow>({
   };
 
   const filterIcon = (column: Header<T> & ColumnMetaData): React.ReactNode => {
-    if (!column.isFilterActive && column.filterIcon) {
-      return column.filterIcon;
+    if (!column.isFilterActive && column.control) {
+      return <div className={cnTableHeader('Buttons_control')}>{column.control({ column })}</div>;
     }
 
     return null;
@@ -190,7 +190,7 @@ export const TableHeader = <T extends TableRow>({
                 className={cnTableHeader('Buttons', {
                   isSortingActive: column.isSortingActive,
                   isFilterActive: column.isFilterActive,
-                  isFilterIconActive: Boolean(column.filterIcon),
+                  isFilterIconActive: Boolean(column.control),
                   verticalAlign: headerVerticalAlign,
                 })}
               >

--- a/src/components/Table/Header/TableHeader.tsx
+++ b/src/components/Table/Header/TableHeader.tsx
@@ -90,7 +90,7 @@ export const TableHeader = <T extends TableRow>({
   };
 
   const getFilterPopover = (column: Header<T> & ColumnMetaData): React.ReactNode => {
-    if (!filters || !column.accessor || column.control) {
+    if (!filters || !column.accessor) {
       return null;
     }
     const curFilter = filters.find(({ field }) => field === column.accessor);
@@ -127,7 +127,7 @@ export const TableHeader = <T extends TableRow>({
     ) : null;
   };
 
-  const filterIcon = (column: Header<T> & ColumnMetaData): React.ReactNode => {
+  const control = (column: Header<T> & ColumnMetaData): React.ReactNode => {
     if (!column.isFilterActive && column.control) {
       return <div className={cnTableHeader('Buttons_control')}>{column.control({ column })}</div>;
     }
@@ -190,11 +190,11 @@ export const TableHeader = <T extends TableRow>({
                 className={cnTableHeader('Buttons', {
                   isSortingActive: column.isSortingActive,
                   isFilterActive: column.isFilterActive,
-                  isFilterIconActive: Boolean(column.control),
+                  isControlActive: Boolean(column.control),
                   verticalAlign: headerVerticalAlign,
                 })}
               >
-                {filterIcon(column)}
+                {control(column)}
 
                 {column.sortable && (
                   <Button

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -138,6 +138,7 @@ export type TableColumn<T extends TableRow> = {
   width?: ColumnWidth;
   mergeCells?: boolean;
   position?: Position;
+  filterIcon?: React.ReactNode;
 } & (GroupColumnAddition<T> | SingleColumnAddition<T>);
 
 export type TableProps<T extends TableRow> = {

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -131,7 +131,7 @@ type GroupColumnAddition<T extends TableRow> = {
   [K in keyof ColumnBase<T>]?: never;
 };
 export interface TableControl<T extends TableRow> {
-  column: (Header<T> & ColumnMetaData) | undefined;
+  column: Header<T> & ColumnMetaData;
 }
 
 export type TableColumn<T extends TableRow> = {

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -130,6 +130,9 @@ type GroupColumnAddition<T extends TableRow> = {
 } & {
   [K in keyof ColumnBase<T>]?: never;
 };
+export interface TableControl<T extends TableRow> {
+  column: (Header<T> & ColumnMetaData) | undefined;
+}
 
 export type TableColumn<T extends TableRow> = {
   title: React.ReactNode;
@@ -138,7 +141,7 @@ export type TableColumn<T extends TableRow> = {
   width?: ColumnWidth;
   mergeCells?: boolean;
   position?: Position;
-  filterIcon?: React.ReactNode;
+  control?: ({ column }: TableControl<T>) => React.ReactNode;
 } & (GroupColumnAddition<T> | SingleColumnAddition<T>);
 
 export type TableProps<T extends TableRow> = {

--- a/src/components/Table/__mock__/data.mock.tsx
+++ b/src/components/Table/__mock__/data.mock.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 
+import { IconAdd } from '../../../icons/IconAdd/IconAdd';
+import { IconRemove } from '../../../icons/IconRemove/IconRemove';
 import { isNotNil } from '../../../utils/type-guards';
 import { Badge } from '../../Badge/Badge';
+import { Button } from '../../Button/Button';
 import { TableChoiceGroupFilter } from '../ChoiceGroupFilter/TableChoiceGroupFilter';
 import { TableNumberFilter } from '../NumberFilter/TableNumberFilter';
 import { TableFilters as Filters, TableProps } from '../Table';
@@ -1241,4 +1244,22 @@ export const partOfTableDataForCustomTagLabelFunction = {
       },
     },
   ],
+};
+
+export const withIconTableMock = {
+  columns: [
+    {
+      title: 'Имя',
+      accessor: CustomIDs.fullName,
+      sortable: true,
+      filterIcon: <Button size="xs" iconSize="s" view="clear" onlyIcon iconLeft={IconAdd} />,
+    },
+    {
+      title: 'Год регистрации',
+      accessor: CustomIDs.yearOfRegistration,
+      sortable: true,
+      filterIcon: <Button size="xs" iconSize="s" view="clear" onlyIcon iconLeft={IconRemove} />,
+    },
+  ],
+  rows: rowsForCustomTagLabelFunction,
 };

--- a/src/components/Table/__mock__/data.mock.tsx
+++ b/src/components/Table/__mock__/data.mock.tsx
@@ -1246,19 +1246,19 @@ export const partOfTableDataForCustomTagLabelFunction = {
   ],
 };
 
-export const withIconTableMock = {
+export const withControlTableMock = {
   columns: [
     {
       title: 'Имя',
       accessor: CustomIDs.fullName,
       sortable: true,
-      filterIcon: <Button size="xs" iconSize="s" view="clear" onlyIcon iconLeft={IconAdd} />,
+      control: () => <Button size="xs" iconSize="s" view="clear" onlyIcon iconLeft={IconAdd} />,
     },
     {
       title: 'Год регистрации',
       accessor: CustomIDs.yearOfRegistration,
       sortable: true,
-      filterIcon: <Button size="xs" iconSize="s" view="clear" onlyIcon iconLeft={IconRemove} />,
+      control: () => <Button size="xs" iconSize="s" view="clear" onlyIcon iconLeft={IconRemove} />,
     },
   ],
   rows: rowsForCustomTagLabelFunction,

--- a/src/components/Table/__mock__/data.mock.tsx
+++ b/src/components/Table/__mock__/data.mock.tsx
@@ -1252,14 +1252,63 @@ export const withControlTableMock = {
       title: 'Имя',
       accessor: CustomIDs.fullName,
       sortable: true,
+      filterer: rangeFilterer,
+      component: {
+        name: TableNumberFilter,
+      },
       control: () => <Button size="xs" iconSize="s" view="clear" onlyIcon iconLeft={IconAdd} />,
     },
     {
       title: 'Год регистрации',
       accessor: CustomIDs.yearOfRegistration,
       sortable: true,
+      filterer: rangeFilterer,
+      component: {
+        name: TableNumberFilter,
+      },
       control: () => <Button size="xs" iconSize="s" view="clear" onlyIcon iconLeft={IconRemove} />,
     },
   ],
   rows: rowsForCustomTagLabelFunction,
+  filters: [
+    {
+      id: CustomIDs.fullName,
+      name: 'Выбранные инициалы: ',
+      field: CustomIDs.fullName,
+      filterer: customFilters[0].filterer,
+      component: {
+        name: TableTextFilter,
+        props: {
+          withSearch: true,
+          items: [
+            {
+              name: rowsForCustomTagLabelFunction[0].fullName,
+              value: rowsForCustomTagLabelFunction[0].fullName,
+            },
+            {
+              name: rowsForCustomTagLabelFunction[1].fullName,
+              value: rowsForCustomTagLabelFunction[1].fullName,
+            },
+            {
+              name: rowsForCustomTagLabelFunction[2].fullName,
+              value: rowsForCustomTagLabelFunction[2].fullName,
+            },
+            {
+              name: rowsForCustomTagLabelFunction[3].fullName,
+              value: rowsForCustomTagLabelFunction[3].fullName,
+            },
+          ],
+        },
+      },
+    },
+    {
+      id: CustomIDs.yearOfRegistration,
+      name: 'Год регистрации: ',
+      field: CustomIDs.yearOfRegistration,
+      filterer: rangeFilterer,
+      component: {
+        name: TableNumberFilter,
+      },
+    },
+  ],
 };

--- a/src/components/Table/__stories__/Table.docs.mdx
+++ b/src/components/Table/__stories__/Table.docs.mdx
@@ -154,6 +154,28 @@ type OrderType = 'ASC' | 'DESC' | 'asc' | 'desc';
 ];
 ```
 
+#### filterIcon
+
+В случае, когда вам необходимо добавить кастомную иконку справа(в header), то вы можете воспользоваться `filterIcon`
+В него необходимо передать `ReactNode`
+
+```tsx
+const columns = [
+  {
+    title: '№',
+    accessor: 'id',
+    align: 'center',
+    filterIcon: <Button size="xs" iconSize="s" view="clear" onlyIcon iconLeft={IconAdd} />,
+  },
+  {
+    title: 'Имя',
+    accessor: 'name',
+    align: 'center',
+    filterIcon: <Button size="xs" iconSize="s" view="clear" onlyIcon iconLeft={IconRemove} />,
+  },
+];
+```
+
 #### Кастомный фильтр
 
 Нестандартные компоненты для фильтрации можно добавить в объекте `component`. Например, так:

--- a/src/components/Table/__stories__/Table.docs.mdx
+++ b/src/components/Table/__stories__/Table.docs.mdx
@@ -60,6 +60,8 @@ import { Preview } from '@storybook/addon-docs/dist/blocks';
 
 `order` — устанавливает порядок [сортировки](#сортировка) по умолчанию.
 
+`control` — Добавляет компонент, справа от названия колонки, например checkbox
+
 В этой таблице будет две колонки — номер и имя.
 
 ```ts
@@ -76,6 +78,32 @@ import { Preview } from '@storybook/addon-docs/dist/blocks';
     accessor: 'name',
     sortable: true,
     order: 'ASC',
+  },
+];
+```
+
+#### control
+
+В случае, когда вам необходимо добавить кастомную контрол справа(в header), то вы можете воспользоваться `control`
+В него необходимо передать `({ column }: TableControl<{}>) => ReactNode`
+
+```tsx
+const columns = [
+  {
+    title: '№',
+    accessor: 'id',
+    align: 'center',
+    control: ({ column }: TableControl<{}>) => (
+      <Button size="xs" iconSize="s" view="clear" onlyIcon iconLeft={IconAdd} />
+    ),
+  },
+  {
+    title: 'Имя',
+    accessor: 'name',
+    align: 'center',
+    control: ({ column }: TableControl<{}>) => (
+      <Button size="xs" iconSize="s" view="clear" onlyIcon iconLeft={IconRemove} />
+    ),
   },
 ];
 ```
@@ -150,28 +178,6 @@ type OrderType = 'ASC' | 'DESC' | 'asc' | 'desc';
     name: 'Антон',
     filterer: (value) => value === 'Антон',
     field: 'name',
-  },
-];
-```
-
-#### filterIcon
-
-В случае, когда вам необходимо добавить кастомную иконку справа(в header), то вы можете воспользоваться `filterIcon`
-В него необходимо передать `ReactNode`
-
-```tsx
-const columns = [
-  {
-    title: '№',
-    accessor: 'id',
-    align: 'center',
-    filterIcon: <Button size="xs" iconSize="s" view="clear" onlyIcon iconLeft={IconAdd} />,
-  },
-  {
-    title: 'Имя',
-    accessor: 'name',
-    align: 'center',
-    filterIcon: <Button size="xs" iconSize="s" view="clear" onlyIcon iconLeft={IconRemove} />,
   },
 ];
 ```

--- a/src/components/Table/__stories__/Table.stories.tsx
+++ b/src/components/Table/__stories__/Table.stories.tsx
@@ -224,14 +224,14 @@ const WithOnRowHoverContent = <T extends TableRow>(): JSX.Element => {
     ),
   }));
 
-  const columns: Array<TableColumn<typeof rows[number]>> = [
+  const columns: TableColumn<typeof rows[number]>[] = [
     {
       title: 'Появится кнопка при наведении',
       accessor: 'button',
       align: 'center',
       width: 120,
     },
-    ...tableData.columns,
+    ...(tableData.columns as TableColumn<typeof rows[number]>[]),
   ];
 
   return (

--- a/src/components/Table/__stories__/Table.stories.tsx
+++ b/src/components/Table/__stories__/Table.stories.tsx
@@ -15,7 +15,7 @@ import {
   tableWithExpandableRowsData,
   tableWithMergedCellsData,
   tableWithMultiLevelHeadersData,
-  withIconTableMock,
+  withControlTableMock,
 } from '../__mock__/data.mock';
 import { IconCopy } from '../../../icons/IconCopy/IconCopy';
 import { updateAt } from '../../../utils/array';
@@ -483,8 +483,8 @@ export const WithRowActions = createStory(() => <WithRowCreationAndDeletion />, 
   name: 'с добавлением/удалением строк',
 });
 
-export const WithIcon = createStory(() => <Table {...getKnobs(withIconTableMock)} />, {
-  name: 'С использованием filterIcon',
+export const WithIcon = createStory(() => <Table {...getKnobs(withControlTableMock)} />, {
+  name: 'С использованием control',
 });
 
 export default createMetadata({

--- a/src/components/Table/__stories__/Table.stories.tsx
+++ b/src/components/Table/__stories__/Table.stories.tsx
@@ -15,6 +15,7 @@ import {
   tableWithExpandableRowsData,
   tableWithMergedCellsData,
   tableWithMultiLevelHeadersData,
+  withIconTableMock,
 } from '../__mock__/data.mock';
 import { IconCopy } from '../../../icons/IconCopy/IconCopy';
 import { updateAt } from '../../../utils/array';
@@ -480,6 +481,10 @@ export const withCustomTagLabelFunction = createStory(
 
 export const WithRowActions = createStory(() => <WithRowCreationAndDeletion />, {
   name: 'с добавлением/удалением строк',
+});
+
+export const WithIcon = createStory(() => <Table {...getKnobs(withIconTableMock)} />, {
+  name: 'С использованием filterIcon',
 });
 
 export default createMetadata({

--- a/src/components/Table/__tests__/Table.test.tsx
+++ b/src/components/Table/__tests__/Table.test.tsx
@@ -124,6 +124,28 @@ describe('Компонент Table', () => {
       });
     });
 
+    describe('проверка работы добавления control', () => {
+      it('control отображается корректно', () => {
+        /** Добавляем нашу filterIcon */
+        defaultProps.columns = defaultProps.columns.map((column) => {
+          const cloneColumn = { ...column };
+
+          cloneColumn.control = () => <div className="filterIcon">test</div>;
+
+          return cloneColumn;
+        });
+
+        renderComponent(defaultProps);
+
+        const filterIcons = screen.getAllByText('test', {
+          selector: '.TableCell-Wrapper .filterIcon',
+        });
+
+        /** Проверяем, что корректно появились компоненты с filterIcon */
+        expect(filterIcons.length > 0).toBeTruthy();
+      });
+    });
+
     describe('проверка объединения ячеек', () => {
       const rowsWithMergeCells = [
         {
@@ -288,26 +310,6 @@ describe('Компонент Table', () => {
       expect(onFiltersUpdated).toBeCalled();
       expect(onFiltersUpdated).toBeCalledTimes(2);
       expect(onFiltersUpdated).toHaveReturnedTimes(2);
-    });
-
-    it('filterIcon отображается корректно', () => {
-      /** Добавляем нашу filterIcon */
-      defaultProps.columns = defaultProps.columns.map((column) => {
-        const cloneColumn = { ...column };
-
-        cloneColumn.filterIcon = <div className="filterIcon">test</div>;
-
-        return cloneColumn;
-      });
-
-      renderComponent(defaultProps);
-
-      const filterIcons = screen.getAllByText('test', {
-        selector: '.TableCell-Wrapper .filterIcon',
-      });
-
-      /** Проверяем, что корректно появились компоненты с filterIcon */
-      expect(filterIcons.length > 0).toBeTruthy();
     });
   });
 });

--- a/src/components/Table/__tests__/Table.test.tsx
+++ b/src/components/Table/__tests__/Table.test.tsx
@@ -289,5 +289,25 @@ describe('Компонент Table', () => {
       expect(onFiltersUpdated).toBeCalledTimes(2);
       expect(onFiltersUpdated).toHaveReturnedTimes(2);
     });
+
+    it('filterIcon отображается корректно', () => {
+      /** Добавляем нашу filterIcon */
+      defaultProps.columns = defaultProps.columns.map((column) => {
+        const cloneColumn = { ...column };
+
+        cloneColumn.filterIcon = <div className="filterIcon">test</div>;
+
+        return cloneColumn;
+      });
+
+      renderComponent(defaultProps);
+
+      const filterIcons = screen.getAllByText('test', {
+        selector: '.TableCell-Wrapper .filterIcon',
+      });
+
+      /** Проверяем, что корректно появились компоненты с filterIcon */
+      expect(filterIcons.length > 0).toBeTruthy();
+    });
   });
 });


### PR DESCRIPTION
… custom component to table head

closes 1715

## Описание изменений
На основе issue https://github.com/gazprom-neft/consta-uikit/issues/1715
Добавлено новое свойство в таблицу(поле columns - filterIcon)
Данное поле позволяет передавать кастомный компонент в заголовки таблицы

## Чек-лист

- [ ] PR: направлен в правильную ветку
- [ ] PR: назначен исполнитель PR и указаны нужные лейблы
- [x] PR: проверен diff, ничего лишнего в PR не попало
- [x] PR: прилинкованы затронутые issue и связанные PR
- [x] PR: есть описание изменений
- [x] JS: нет варнингов и ошибок в консоли браузера
- [x] Тесты: новый функционал и исправленные баги покрыты тестами
- [x] Документация: отражены все изменения в API компонентов и описаны важные особенности реализации или использования
- [x] Сторибук: для компонентов написаны или обновлены stories
- [ ] Верстка: используются [переменные](../src/components/Theme)
- [x] Верстка: проверена с разным количеством контента

## Опционально

- [ ] Доработки: заведены задачи для дальнейшей работы, если что-то решено не править в текущем пулл-реквесте
- [ ] Коммиты: проименованы в соответствии с [правилами](https://consta-uikit.vercel.app/?path=/docs/common-develop-commits-style--page)
